### PR TITLE
4 command request addphrase

### DIFF
--- a/.github/ISSUE_TEMPLATE/command-request.md
+++ b/.github/ISSUE_TEMPLATE/command-request.md
@@ -1,0 +1,24 @@
+---
+name: Command request
+about: Suggest a command for the bot
+title: "[COMMAND REQUEST]"
+labels: command, enhancement
+assignees: ''
+
+---
+
+**What is the name of the command you'd like ?**
+Name of the command (eightball, etc)
+
+**Does your command require parameters ?**
+A bullet list of parameters and what it should be:
+- phrase: all the text after the command *or* the full text of the message replied to
+
+**What is the syntax of your command ?**
+/command [ { param } ]
+
+**Describe the response of the bot**
+A clear description of what the bot should do as answer to the command.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/telegram_bot_build.yml
+++ b/.github/workflows/telegram_bot_build.yml
@@ -1,6 +1,8 @@
 name: Telegram Bot Build
 on:
   push:
+    branches:
+      - main
     paths:
       - telegram_bot/**
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/*.*-env
 rebuild.sh
+.tmp
 
 # Logs
 logs

--- a/telegram_bot/models/User.js
+++ b/telegram_bot/models/User.js
@@ -1,0 +1,4 @@
+const mongoose = require('mongoose');
+const userSchema = require('../schemas/User');
+
+module.exports = new mongoose.model('User', userSchema, 'authorized_telegram_users');

--- a/telegram_bot/schemas/User.js
+++ b/telegram_bot/schemas/User.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+module.exports = new mongoose.Schema({
+	username: {
+		type: String,
+		required: true
+	}
+})

--- a/telegram_bot/telegram/commands/addphrase.js
+++ b/telegram_bot/telegram/commands/addphrase.js
@@ -1,0 +1,36 @@
+const BullshitModel = require('../../models/Bullshit');
+const UserModel = require('../../models/User');
+const { sendText, escape } = require('../helpers');
+
+const cmd_addphrase = (body, tokens) => {
+	UserModel.countDocuments({username: body.message.from.username})
+	.then((count) => {
+
+		let text = '';
+		const username = body.message.from.username;
+		const date = new Date();
+
+		if (!count){
+			let msg = `You (${username}) don't have rights to use this command.`;
+			sendText(body.message.chat.id, escape(msg));
+			return ;
+		}
+		else if (!tokens.length) {
+			let msg = `There's nothing to save...`;
+			console.log('request-body:');
+			console.log(body);
+			sendText(body.message.chat.id, escape(msg));
+			return ;
+		}
+		tokens.forEach((token) => {text += token + ' '; });
+		text = text.trimEnd();
+		new BullshitModel({text: text, user: username, date: date}).save();
+		let msg = `\\>_${escape(text)}_\\< saved\\.`;
+		sendText(body.message.chat.id, msg);
+	})
+	.catch((error) => {
+		console.error(error);
+	});
+}
+
+module.exports = cmd_addphrase;

--- a/telegram_bot/telegram/index.js
+++ b/telegram_bot/telegram/index.js
@@ -7,11 +7,11 @@ const cmd_eightball = require('./commands/eightball.js');
 
 const handleCommand = (body, command, tokens) => {
 	command = command.substring(1);
-	console.log(command);
 
 	const commands = {
 		test: cmd_test,
-		eightball: cmd_eightball
+		eightball: cmd_eightball,
+		addphrase: require('./commands/addphrase.js')
 	}
 
 	if (command == 'start')


### PR DESCRIPTION
# Describe your changes

Please include a summary of the changes and the related issue.

- Added a new command to the bot which let's authorised users save new _bullshit_ in the database that the bot can send via the `eightball` command.
- There's two way of saving texts:
    - By sending text along the command : `/addphrase <text to add>` ( fffe99a )
    - By replying to a message with only the `/addphrase` ( ca6ad00 )
- Added a new Mongoose model / schema : User ( fffe99a )

Also include a list of newly installed NPM packages (if any).
No new NPM packages were needed.

Fixes #4 

# Type of change

Please delete unrelevant option.

- [x] New feature (non-breaking change which adds functionality) 

# How has this been tested ?

Tested locally by sending manual request mimicking the requests sent by telegram and changing values directly in the json body of the request.