### PR TITLE
4 command request addphrase bugfix

### DIFF
--- a/PULL_REQUEST_TEMPLATE /pull_request_template.md
+++ b/PULL_REQUEST_TEMPLATE /pull_request_template.md
@@ -1,0 +1,19 @@
+## Describe your changes
+
+Please include a summary of the changes and the related issue.
+
+Also include a list of newly installed NPM packages (if any).
+
+Fixes #<issue number>
+
+# Type of change
+
+Please delete unrelevant option.
+
+- [x] Bug fix (non-breaking change which fixes an issue) 
+- [x] New feature (non-breaking change which adds functionality) 
+- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+# How has this been tested ?
+
+Please include a description of the tests made.

--- a/telegram_bot/telegram/commands/addphrase.js
+++ b/telegram_bot/telegram/commands/addphrase.js
@@ -16,6 +16,7 @@ const handleReplyTo = (body) => {
 }
 
 const handleSameMsg = (body, tokens) => {
+	const username = body.message.from.username;
 	let text = '';
 	tokens.forEach((token) => {text += token + ' '; });
 	text = text.trimEnd();


### PR DESCRIPTION
## Describe your changes

Fixed the `ReferenceError` caused by `username` not declared in `handleSameMsg` command.

Also include a list of newly installed NPM packages (if any).

Fixes #4 

# Type of change

Please delete unrelevant option.

- [x] Bug fix (non-breaking change which fixes an issue) 

# How has this been tested ?

Check sending messages with `reply_to_message` and also without it.
